### PR TITLE
Set gradle to target JDK 8 for java classes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ val group = "com.github.kotlin_graphics"
 val moduleName = "$group.gln"
 val kotestVersion = "4.0.5"
 
-
 val kx = "com.github.kotlin-graphics"
 val unsignedVersion = "87630c4d"
 val koolVersion = "3be0cc2f"
@@ -26,6 +25,9 @@ val lwjglNatives = when (current()) {
     LINUX -> "linux"
     else -> "macos"
 }
+
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
See https://github.com/kotlin-graphics/imgui/pull/152

One of my users was getting a `java.lang.UnsupportedClassVersionError` trying to access `MemoryTextDecoding`. This PR should fix that.